### PR TITLE
fix(typo): Roselie -> Roseli

### DIFF
--- a/calcs/js/battle.js
+++ b/calcs/js/battle.js
@@ -902,7 +902,7 @@ function Calculate_Attack(sender)
 		}
 
 		// TRB FAIRY
-		if(Defender.Item == "Roselie Berry" && Defender.Ability != "KL" && AttackType == "FA" && Compatibility > 1)
+		if(Defender.Item == "Roseli Berry" && Defender.Ability != "KL" && AttackType == "FA" && Compatibility > 1)
 		{
 			TRB = .5; alert("The berry was used.");
 			$('#hitem'+d)[0].selectize.setValue("(none)");


### PR DESCRIPTION
This typo was making the item calculation not match to the actual selected option, meaning Roseli Berry didn't work.